### PR TITLE
Support single-planar drivers

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -105,15 +105,15 @@ Context::Context(DriverData* driver_data, V4L2M2MDevice& dev, fourcc pixelformat
     , driver_data(driver_data)
     , device(dev)
 {
-    device.set_format(V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, pixelformat, picture_width, picture_height);
+    device.set_format(device.output_buf_type, pixelformat, picture_width, picture_height);
 
     // Now that the output format is set, we can set the capture format and allocate the surfaces.
     createSurfacesDeferred(driver_data, *this, surface_ids);
 
-    device.request_buffers(V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, surface_ids.size());
+    device.request_buffers(device.output_buf_type, surface_ids.size());
 
     for (unsigned i = 0; i < surface_ids.size(); i++) {
-        driver_data->surfaces.at(i).source_buffer = std::cref(device.buffer(V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, i));
+        driver_data->surfaces.at(i).source_buffer = std::cref(device.buffer(device.output_buf_type, i));
     }
 
     device.set_streaming(true);
@@ -122,7 +122,7 @@ Context::Context(DriverData* driver_data, V4L2M2MDevice& dev, fourcc pixelformat
 Context::~Context()
 {
     device.set_streaming(false);
-    device.request_buffers(V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, 0);
+    device.request_buffers(device.capture_buf_type, 0);
 }
 
 VAStatus createContext(VADriverContextP va_context, VAConfigID config_id, int picture_width, int picture_height,

--- a/src/h264.cc
+++ b/src/h264.cc
@@ -551,7 +551,7 @@ int H264Context::set_controls()
 std::set<VAProfile> H264Context::supported_profiles(const V4L2M2MDevice& device)
 {
     // TODO: query `h264_profile` control for more details
-    return (device.format_supported(V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_PIX_FMT_H264_SLICE))
+    return (device.format_supported(device.output_buf_type, V4L2_PIX_FMT_H264_SLICE))
         ? std::set<VAProfile>({ VAProfileH264Main, VAProfileH264High, VAProfileH264ConstrainedBaseline,
               VAProfileH264MultiviewHigh, VAProfileH264StereoHigh })
         : std::set<VAProfile>();

--- a/src/mpeg2.cc
+++ b/src/mpeg2.cc
@@ -185,7 +185,7 @@ int MPEG2Context::set_controls()
 
 std::set<VAProfile> MPEG2Context::supported_profiles(const V4L2M2MDevice& device)
 {
-    return (device.format_supported(V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_PIX_FMT_MPEG2_SLICE))
+    return (device.format_supported(device.output_buf_type, V4L2_PIX_FMT_MPEG2_SLICE))
         ? std::set<VAProfile>({ VAProfileMPEG2Main, VAProfileMPEG2Simple })
         : std::set<VAProfile>();
 };

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -56,7 +56,7 @@ namespace {
 decltype(formats)::const_iterator matching_format(const V4L2M2MDevice& device, uint32_t format)
 {
     return std::ranges::find_if(formats, [&](auto&& f) {
-        return f.va.rt_format == format && device.format_supported(V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, f.v4l2.format);
+        return f.va.rt_format == format && device.format_supported(device.capture_buf_type, f.v4l2.format);
     });
 }
 
@@ -99,11 +99,11 @@ void createSurfacesDeferred(DriverData* driver_data, const Context& context, std
 
     auto [format, derive_layout] = matching_format(context.device, surface.format)->v4l2;
 
-    context.device.set_format(V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, format, surface.width, surface.height);
+    context.device.set_format(context.device.capture_buf_type, format, surface.width, surface.height);
 
     v4l2_pix_format_mplane* driver_format = &context.device.capture_format.fmt.pix_mp;
 
-    context.device.request_buffers(V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, surface_ids.size());
+    context.device.request_buffers(context.device.capture_buf_type, surface_ids.size());
 
     for (unsigned i = 0; i < surface_ids.size(); i++) {
         auto& surface = driver_data->surfaces.at(surface_ids[i]);
@@ -122,7 +122,7 @@ void createSurfacesDeferred(DriverData* driver_data, const Context& context, std
             }
         }
 
-        surface.destination_buffer = std::cref(context.device.buffer(V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, i));
+        surface.destination_buffer = std::cref(context.device.buffer(context.device.capture_buf_type, i));
     }
 }
 

--- a/src/v4l2.cc
+++ b/src/v4l2.cc
@@ -161,7 +161,7 @@ std::vector<std::pair<std::string, std::optional<std::string>>> V4L2M2MDevice::e
     for (auto&& media_device : enumerate_media_devices(ctx.get())) {
         for (auto&& video_device : enumerate_video_devices(ctx.get(), media_device)) {
             int fd = errno_wrapper(open, video_device.c_str(), O_RDONLY);
-            if (query_capabilities(fd) & V4L2_CAP_VIDEO_M2M_MPLANE) {
+            if (query_capabilities(fd) & required_capabilities) {
                 result.emplace_back(video_device, media_device);
             }
         }
@@ -271,7 +271,7 @@ V4L2M2MDevice::V4L2M2MDevice(const std::string& video_path, const std::optional<
     , capture_format(get_format(video_fd, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE))
     , output_format(get_format(video_fd, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE))
 {
-    if (!(query_capabilities(video_fd) & (V4L2_CAP_VIDEO_M2M | V4L2_CAP_VIDEO_M2M_MPLANE))) {
+    if (!(query_capabilities(video_fd) & required_capabilities)) {
         std::runtime_error("Missing device capabilities");
     }
 }

--- a/src/v4l2.h
+++ b/src/v4l2.h
@@ -82,6 +82,9 @@ public:
 
     int video_fd;
     int media_fd;
+    const uint32_t capabilities;
+    const v4l2_buf_type capture_buf_type;
+    const v4l2_buf_type output_buf_type;
     v4l2_format capture_format;
     v4l2_format output_format;
     std::set<fourcc> supported_output_formats;

--- a/src/v4l2.h
+++ b/src/v4l2.h
@@ -66,6 +66,8 @@ public:
 
     static std::vector<std::pair<std::string, std::optional<std::string>>> enumerate_devices();
 
+    static const uint32_t required_capabilities = V4L2_CAP_VIDEO_M2M | V4L2_CAP_VIDEO_M2M_MPLANE;
+
     V4L2M2MDevice(const std::string& video_path, const std::optional<std::string>& media_path);
     V4L2M2MDevice(V4L2M2MDevice&& other);
     V4L2M2MDevice& operator=(V4L2M2MDevice&& other);

--- a/src/vp8.cc
+++ b/src/vp8.cc
@@ -266,7 +266,7 @@ int VP8Context::set_controls()
 
 std::set<VAProfile> VP8Context::supported_profiles(const V4L2M2MDevice& device)
 {
-    return (device.format_supported(V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_PIX_FMT_VP8_FRAME))
+    return (device.format_supported(device.output_buf_type, V4L2_PIX_FMT_VP8_FRAME))
         ? std::set<VAProfile>({ VAProfileVP8Version0_3 })
         : std::set<VAProfile>();
 };

--- a/src/vp9.cc
+++ b/src/vp9.cc
@@ -233,7 +233,7 @@ int VP9Context::set_controls()
 std::set<VAProfile> VP9Context::supported_profiles(const V4L2M2MDevice& device)
 {
     // TODO: query `va_profile` control for more details
-    return (device.format_supported(V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_PIX_FMT_VP9_FRAME))
+    return (device.format_supported(device.output_buf_type, V4L2_PIX_FMT_VP9_FRAME))
         ? std::set<VAProfile>(
               { VAProfileVP9Profile0, VAProfileVP9Profile1, VAProfileVP9Profile2, VAProfileVP9Profile3 })
         : std::set<VAProfile>();


### PR DESCRIPTION
The current implementation uses only the multi-planar V4L2 API. Logically, single-planar buffers and multi-planar buffers with a single plane are equivalent though, so supporting the single-planar variant is largely achieved by using the appropriate buffer types and translating the different buffer descriptors when querying and queuing buffers.