### PR TITLE
H264 slice based decoding

### DIFF
--- a/src/h264.cc
+++ b/src/h264.cc
@@ -435,13 +435,9 @@ VAStatus H264Context::store_buffer(const Buffer& buffer) const
     const auto source_data = surface.source_buffer->get().mapping()[0];
     switch (buffer.type) {
     case VASliceDataBufferType:
-        /*
-         * Since there is no guarantee that the allocation
-         * order is the same as the submission order (via
-         * RenderPicture), we can't use a V4L2 buffer directly
-         * and have to copy from a regular buffer.
-         */
-        surface.source_size_used += prefix_data(source_data.data() + surface.source_size_used);
+        if (mode == static_cast<v4l2_stateless_h264_decode_mode>(V4L2_STATELESS_H264_DECODE_MODE_FRAME_BASED)) {
+            surface.source_size_used += prefix_data(source_data.data() + surface.source_size_used);
+        }
 
         if (surface.source_size_used + buffer.size * buffer.count > source_data.size()) {
             return VA_STATUS_ERROR_NOT_ENOUGH_BUFFER;

--- a/src/h264.cc
+++ b/src/h264.cc
@@ -423,6 +423,7 @@ H264Context::H264Context(DriverData* driver_data, V4L2M2MDevice& device, VAProfi
     int picture_height, std::span<VASurfaceID> surface_ids)
     : Context(driver_data, device, V4L2_PIX_FMT_H264_SLICE, picture_width, picture_height, surface_ids)
     , profile(va_profile_to_profile_idc(profile))
+    , mode(static_cast<v4l2_stateless_h264_decode_mode>(device.get_control(V4L2_CID_STATELESS_H264_DECODE_MODE)))
 {
 }
 

--- a/src/h264.cc
+++ b/src/h264.cc
@@ -538,7 +538,7 @@ int H264Context::set_controls()
     };
 
     try {
-        device.set_controls(surface.request_fd, std::span(controls, i));
+        device.set_ext_controls(surface.request_fd, std::span(controls, i));
     } catch (std::runtime_error& e) {
         return VA_STATUS_ERROR_OPERATION_FAILED;
     }

--- a/src/h264.h
+++ b/src/h264.h
@@ -67,4 +67,5 @@ public:
 
     uint8_t profile;
     struct h264_dpb dpb;
+    v4l2_stateless_h264_decode_mode mode;
 };

--- a/src/mpeg2.cc
+++ b/src/mpeg2.cc
@@ -113,7 +113,7 @@ int MPEG2Context::set_controls()
     sequence.chroma_format = 1; // 4:2:0
 
     try {
-        device.set_control(surface.request_fd, V4L2_CID_STATELESS_MPEG2_SEQUENCE, &sequence, sizeof(sequence));
+        device.set_ext_control(surface.request_fd, V4L2_CID_STATELESS_MPEG2_SEQUENCE, &sequence, sizeof(sequence));
     } catch (std::runtime_error& e) {
         return VA_STATUS_ERROR_OPERATION_FAILED;
     }
@@ -149,7 +149,7 @@ int MPEG2Context::set_controls()
             | (va_picture->picture_coding_extension.bits.progressive_frame ? V4L2_MPEG2_PIC_FLAG_PROGRESSIVE : 0));
 
     try {
-        device.set_control(surface.request_fd, V4L2_CID_STATELESS_MPEG2_PICTURE, &picture, sizeof(picture));
+        device.set_ext_control(surface.request_fd, V4L2_CID_STATELESS_MPEG2_PICTURE, &picture, sizeof(picture));
     } catch (std::runtime_error& e) {
         return VA_STATUS_ERROR_OPERATION_FAILED;
     }
@@ -173,7 +173,7 @@ int MPEG2Context::set_controls()
         }
 
         try {
-            device.set_control(
+            device.set_ext_control(
                 surface.request_fd, V4L2_CID_STATELESS_MPEG2_QUANTISATION, &quantisation, sizeof(quantisation));
         } catch (std::runtime_error& e) {
             return VA_STATUS_ERROR_OPERATION_FAILED;

--- a/src/v4l2.cc
+++ b/src/v4l2.cc
@@ -375,17 +375,17 @@ const V4L2M2MDevice::Buffer& V4L2M2MDevice::buffer(v4l2_buf_type type, unsigned 
     return (V4L2_TYPE_IS_CAPTURE(type) ? capture_buffers : output_buffers)[index];
 }
 
-void V4L2M2MDevice::set_control(int request_fd, unsigned id, void* data, unsigned size)
+void V4L2M2MDevice::set_ext_control(int request_fd, unsigned id, void* data, unsigned size)
 {
     v4l2_ext_control control = {
         .id = id,
         .size = size,
         .ptr = data,
     };
-    set_controls(request_fd, std::span(&control, 1));
+    set_ext_controls(request_fd, std::span(&control, 1));
 }
 
-void V4L2M2MDevice::set_controls(int request_fd, std::span<v4l2_ext_control> controls)
+void V4L2M2MDevice::set_ext_controls(int request_fd, std::span<v4l2_ext_control> controls)
 {
     struct v4l2_ext_controls meta = {
         .count = static_cast<uint32_t>(controls.size()),

--- a/src/v4l2.cc
+++ b/src/v4l2.cc
@@ -375,6 +375,14 @@ const V4L2M2MDevice::Buffer& V4L2M2MDevice::buffer(v4l2_buf_type type, unsigned 
     return (V4L2_TYPE_IS_CAPTURE(type) ? capture_buffers : output_buffers)[index];
 }
 
+int32_t V4L2M2MDevice::get_control(uint32_t id) const {
+    v4l2_control ctrl = {
+        .id = id,
+    };
+    errno_wrapper(ioctl, video_fd, VIDIOC_G_CTRL, &ctrl);
+    return ctrl.value;
+}
+
 void V4L2M2MDevice::set_ext_control(int request_fd, unsigned id, void* data, unsigned size)
 {
     v4l2_ext_control control = {

--- a/src/v4l2.h
+++ b/src/v4l2.h
@@ -76,6 +76,7 @@ public:
     unsigned request_buffers(enum v4l2_buf_type type, unsigned count);
     bool format_supported(v4l2_buf_type type, unsigned pixelformat) const;
     const Buffer& buffer(v4l2_buf_type type, unsigned index);
+    int32_t get_control(uint32_t id) const;
     void set_ext_control(int request_fd, unsigned id, void* data, unsigned size);
     void set_ext_controls(int request_fd, std::span<v4l2_ext_control> controls);
     void set_streaming(bool enable);

--- a/src/v4l2.h
+++ b/src/v4l2.h
@@ -76,8 +76,8 @@ public:
     unsigned request_buffers(enum v4l2_buf_type type, unsigned count);
     bool format_supported(v4l2_buf_type type, unsigned pixelformat) const;
     const Buffer& buffer(v4l2_buf_type type, unsigned index);
-    void set_control(int request_fd, unsigned id, void* data, unsigned size);
-    void set_controls(int request_fd, std::span<v4l2_ext_control> controls);
+    void set_ext_control(int request_fd, unsigned id, void* data, unsigned size);
+    void set_ext_controls(int request_fd, std::span<v4l2_ext_control> controls);
     void set_streaming(bool enable);
 
     int video_fd;

--- a/src/vp8.cc
+++ b/src/vp8.cc
@@ -256,7 +256,7 @@ int VP8Context::set_controls()
         surface.params.vp8.iqmatrix, surface.params.vp8.probabilities);
 
     try {
-        device.set_control(surface.request_fd, V4L2_CID_STATELESS_VP8_FRAME, &frame, sizeof(frame));
+        device.set_ext_control(surface.request_fd, V4L2_CID_STATELESS_VP8_FRAME, &frame, sizeof(frame));
     } catch (std::runtime_error& e) {
         return VA_STATUS_ERROR_OPERATION_FAILED;
     }

--- a/src/vp9.cc
+++ b/src/vp9.cc
@@ -222,7 +222,7 @@ int VP9Context::set_controls()
         } };
 
     try {
-        device.set_controls(surface.request_fd, std::span(controls, 2));
+        device.set_ext_controls(surface.request_fd, std::span(controls, 2));
     } catch (std::runtime_error& e) {
         return VA_STATUS_ERROR_OPERATION_FAILED;
     }


### PR DESCRIPTION
Extends the H264 decoder to work with slice based decoding as well, in addition to the existing frame based decoding. Tested on a Pine A64+ and ROCK 4.